### PR TITLE
Converter should parse multi line questions

### DIFF
--- a/categories/brain-teasers
+++ b/categories/brain-teasers
@@ -445,11 +445,11 @@ C There is remainder
 D The result is twice your original number
 
 #Q Two dice are randomly thrown. What is the possibility that the number, formed by the two digits that come form the dice, is a prime?
-^ 
-A 2:17
-B 35:36
-C 2:9
-D 1:9
+^ 5:12
+A 5:12
+B 5:18
+C 19:36
+D 35:36
 
 #Q Yesterday I heard an interesting conversation in a shop:
 


### PR DESCRIPTION
The converter completely messed up on multi line question strings. With these changes, if you have a question like 
```text
#Q Finish this old phrase:

When you call a dog, he comes right over to you. When you call a cat, she________________.
^ takes a message
A climbs the curtains
B runs away from you
C thinks its dinner time
D takes a message
```

it will be converted to
```json
{
    "question": "Finish this old phrase:\n\nWhen you call a dog, he comes right over to you. When you call a cat, she________________.",
    "answer": "takes a message",
    "choices": [
        "climbs the curtains",
        "runs away from you",
        "thinks its dinner time",
        "takes a message"
    ]
}
```
